### PR TITLE
Fix #5: Replace Expired URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Tested on Windows 7 and Windows 10. Admin privileges are not required.
 
 #### Copy-paste
 
-1. Download any `.bmp` image ([example](http://nsfpl.com/wp-content/uploads/2015/03/jason-derulo.bmp)), call it `derulo.bmp`.
+1. Download any `.bmp` image ([example](https://i7.putstuffonline.com/0rtEegbeDUI/putstuffonline.bmp)), call it `derulo.bmp`.
 
 2. Open CMD
 

--- a/powershell
+++ b/powershell
@@ -27,7 +27,7 @@
 del %CD%\derulo.bmp
 
 :: Download derulo.bmp
-Powershell.exe -executionpolicy remotesigned "Invoke-RestMethod -Uri http://nsfpl.com/wp-content/uploads/2015/03/jason-derulo.bmp -OutFile derulo.bmp"
+Powershell.exe -executionpolicy remotesigned "Invoke-RestMethod -Uri https://i7.putstuffonline.com/0rtEegbeDUI/putstuffonline.bmp -OutFile derulo.bmp"
 
 :: Set the wallpaper to the one supplied
 :: Source: https://social.technet.microsoft.com/Forums/en-US/w7itproui/thread/72a9b4bf-071b-47cd-877d-0c0629a9eb90/#c58b97cd-3a91-4409-80aa-39d53ef638cf


### PR DESCRIPTION
It's surprisingly hard to find free hosting for `.bmp` images, hence the shady website. It works though and is the first one I could find that didn't convert the image into `.png`.